### PR TITLE
Fix build-cache for tags pointing to other commit ids

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -47,7 +47,7 @@ BUILD_COMMIT_ID_FILE=build/__commit_id__
 REQUESTED_BUILD_VERSION_COMMIT=`git ls-remote $LIGHTGBM_REPO_URL $LIGHTGBM_VERSION | cut -f1`
 # No output? Error or queried a valid commit id. Assume it is a commit:
 REQUESTED_BUILD_VERSION_COMMIT=${REQUESTED_BUILD_VERSION_COMMIT:-$LIGHTGBM_VERSION}
-
+echo "Requested build version commit ${REQUESTED_BUILD_VERSION_COMMIT}."
 ## Check build/ for the latest build. Does it match the requested one? If so, skip.
 if [[ -f $BUILD_COMMIT_ID_FILE ]]; then
     BUILT_COMMIT_ID=`cat $BUILD_COMMIT_ID_FILE`
@@ -114,7 +114,7 @@ if [[ "$3" == "--cache" ]]; then
    echo_bold "Copying build..."
    cp -r build build_cache/tmp
    echo_bold "Archiving build cache..."
-   mv build_cache/tmp build_cache/$(cat $BUILD_COMMIT_ID_FILE)
+   mv build_cache/tmp build_cache/${REQUESTED_BUILD_VERSION_COMMIT}
 fi
 
 echo "Build $PACKAGE_VERSION finished for LightGBM $LIGHTGBM_VERSION version."


### PR DESCRIPTION
When using tags, it is possible that the commit id of the tag doesn't match the commit id it points to.

As the build generates the commit_id (actual commit id) through `git rev-parse HEAD`, but triggering a new build is done by a remote query to the repo `git ls-remote $version` there can be mismatches between the two, which lead to cache misses.

With this patch the build_cache stores the requested commit id instead of the actual commit id so it is independent of such mismatches, which break the build caches.

Also, any updated tag will have a new commit id, hence this still preserves uniqueness and consistency of the requested build ids.
