### PR TITLE
Clone to LightGBM folder at all times including forks

### DIFF
--- a/docker/lightgbm-ci-build-env/make_lightgbm.sh
+++ b/docker/lightgbm-ci-build-env/make_lightgbm.sh
@@ -22,7 +22,7 @@ set -e
 
 
 echo "Cloning $LIGHTGBM_REPO_URL ($1)..."
-git clone --recursive "$LIGHTGBM_REPO_URL"; cd LightGBM
+git clone --recursive "$LIGHTGBM_REPO_URL" LightGBM; cd LightGBM
 git config advice.detachedHead false  # Disable warnings for detached head.
 if [[ ! -z "$1" ]]; then
     git checkout "$1"


### PR DESCRIPTION
It now allows for repositories named something other than "LightGBM"