### PR TITLE
Add make_patch.sh to allow debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,34 @@ You can now copy this folder into your project and either run `bash install_jar_
 
 
 
+# Extra: Debugging for developers (local patches)
 
+This explains how to build local patches for LightGBM and have quicker iterations during LightGBM C++ 
+development/debugging. This can be useful to prototype changes in the C++ codebase or debug.
 
+For instance, to perform debugging, one must build LightGBM using the compiler toolchain available 
+on the target machine running the debugger to have symbol compatibility. Using the standard "cross-platform"
+build provided in this repo would lead to symbol compatibility issues, as it uses on purpose a very
+old compiler toolchain to achieve practically a "cross-platform"/universal build that can run on any modern Linux distro.
+
+Patching hence is done in a two-stage process:
+1. Run at least once the base `make.sh` to have the base build.
+2. Patch the base build by calling `make.sh` in patch mode as explained below.
+
+### Preparing the patch build environment
+
+Clone the relevant LightGBM repo/fork to your computer and run CMake with the desired flags:
+```bash
+cd my_lgbm_repo
+mkdir build
+cd build
+cmake .. -DUSE_DEBUG=ON -DUSE_SWIG=ON
+```
+
+### Running `make.sh` in patch mode
+
+After the CMake setup is complete, simply export `$BUILD_LGBM_PATCH_FROM` to that _build_ folder before 
+running `make.sh` as many times as you want.
+
+This will compile LightGBM from source with your settings and patch the base LightGBM build in the provider.
 

--- a/README.md
+++ b/README.md
@@ -49,23 +49,23 @@ You can now copy this folder into your project and either run `bash install_jar_
 
 
 
-# Extra: Debugging for developers (local patches)
+# Extra for developers: Building local patches (Debugging for developers)
 
-This explains how to build local patches for LightGBM and have quicker iterations during LightGBM C++ 
-development/debugging. This can be useful to prototype changes in the C++ codebase or debug.
+This explains how to build local patches from source for LightGBM. This allows quicker iterations during LightGBM C++ 
+development/debugging. 
 
 For instance, to perform debugging, one must build LightGBM using the compiler toolchain available 
-on the target machine running the debugger to have symbol compatibility. Using the standard "cross-platform"
-build provided in this repo would lead to symbol compatibility issues, as it uses on purpose a very
-old compiler toolchain to achieve practically a "cross-platform"/universal build that can run on any modern Linux distro.
+on the target machine running the debugger, otherwise there will be symbol compatibility issues.
 
-Patching hence is done in a two-stage process:
+Patching is done in a two-stage process:
 1. Run at least once the base `make.sh` to have the base build.
-2. Patch the base build by calling `make.sh` in patch mode as explained below.
+2. Patch the base build by calling `make_patch.sh` as explained below.
 
-### Preparing the patch build environment
+## Running `make_patch.sh`
 
-Clone the relevant LightGBM repo/fork to your computer and run CMake with the desired flags:
+### Setup the LightGBM source for compilation
+
+First, clone the LightGBM repo/fork to your computer and run CMake with the desired flags:
 ```bash
 cd my_lgbm_repo
 mkdir build
@@ -73,10 +73,13 @@ cd build
 cmake .. -DUSE_DEBUG=ON -DUSE_SWIG=ON
 ```
 
-### Running `make.sh` in patch mode
+### Create the patch
 
-After the CMake setup is complete, simply export `$BUILD_LGBM_PATCH_FROM` to that _build_ folder before 
-running `make.sh` as many times as you want.
+After the CMake setup is complete, simply run `make_patch.sh` against that folder:
+```bash
+bash make_patch.sh my_lgbm_repo_build_folder
+```
 
-This will compile LightGBM from source with your settings and patch the base LightGBM build in the provider.
+This will compile LightGBM from source with your settings and patch the current base LightGBM build in the [provider](https://github.com/feedzai/feedzai-openml-java/tree/master/openml-lightgbm/lightgbm-builder).
 
+Run `make_patch.sh` every time you want to build a new patch.

--- a/docker/lightgbm-ci-build-env/make_lightgbm.sh
+++ b/docker/lightgbm-ci-build-env/make_lightgbm.sh
@@ -15,18 +15,19 @@
 #  limitations under the License.
 #
 # @author Alberto Ferreira (alberto.ferreira@feedzai.com)
-
+#
+# Usage: $1 serves to checkout a specific commit/tag
 set -e
 
-# Usage: $1 serves to checkout a specific commit/tag
+LIGHTGBM_VERSION="$1"
 
 
-echo "Cloning $LIGHTGBM_REPO_URL ($1)..."
+echo "Cloning $LIGHTGBM_REPO_URL ($LIGHTGBM_VERSION)..."
 git clone --recursive "$LIGHTGBM_REPO_URL" LightGBM; cd LightGBM
 git config advice.detachedHead false  # Disable warnings for detached head.
-if [[ ! -z "$1" ]]; then
-    git checkout "$1"
-    git submodule update --init # needed to fetch the new submodules in dev branches
+if [[ ! -z "$LIGHTGBM_VERSION" ]]; then
+    git checkout "$LIGHTGBM_VERSION"
+    git submodule update --init --recursive # needed to fetch the new submodules in dev branches
 fi
 mkdir build ; cd build
 cmake .. -DUSE_SWIG=ON

--- a/make.sh
+++ b/make.sh
@@ -17,27 +17,11 @@
 # @author Alberto Ferreira (alberto.ferreira@feedzai.com)
 
 set -e
-function echo_stage () {
-    echo -e "\n\n\e[1m\e[32m>>>\e[0m \e[1m$1\e[0m\n"
-}
 
-function echo_bold() {
-    echo -e "\e[1m$1\e[0m"
-}
+function echo_stage () { echo -e "\n\n\e[1m\e[32m>>>\e[0m \e[1m$1\e[0m\n"; }
+function echo_bold() { echo -e "\e[1m$1\e[0m"; }
 
 export LIGHTGBM_REPO_URL="${LIGHTGBM_REPO_URL:-https://github.com/microsoft/LightGBM}"
-
-if [[ ! -z "$BUILD_LGBM_PATCH_FROM" ]]; then
-  echo_stage "Building LGBM patch from source!"
-  CWD="$(pwd)"
-  cd "$BUILD_LGBM_PATCH_FROM"
-  make -j4
-  find . -name "*.so" -exec cp {} "${CWD}/build" \;
-  cp lightgbmlib.jar "${CWD}/build"
-  # If not available on your platform comment loading this shared library during debugging:
-  cp /usr/lib/x86_64-linux-gnu/libgomp.so.1.0.0 "${CWD}/build"
-  exit
-fi
 
 
 LIGHTGBM_VERSION=$([[ -z "$1" ]] && echo "master" || echo "$1")

--- a/make.sh
+++ b/make.sh
@@ -17,8 +17,28 @@
 # @author Alberto Ferreira (alberto.ferreira@feedzai.com)
 
 set -e
+function echo_stage () {
+    echo -e "\n\n\e[1m\e[32m>>>\e[0m \e[1m$1\e[0m\n"
+}
+
+function echo_bold() {
+    echo -e "\e[1m$1\e[0m"
+}
 
 export LIGHTGBM_REPO_URL="${LIGHTGBM_REPO_URL:-https://github.com/microsoft/LightGBM}"
+
+if [[ ! -z "$BUILD_LGBM_PATCH_FROM" ]]; then
+  echo_stage "Building LGBM patch from source!"
+  CWD="$(pwd)"
+  cd "$BUILD_LGBM_PATCH_FROM"
+  make -j4
+  find . -name "*.so" -exec cp {} "${CWD}/build" \;
+  cp lightgbmlib.jar "${CWD}/build"
+  # If not available on your platform comment loading this shared library during debugging:
+  cp /usr/lib/x86_64-linux-gnu/libgomp.so.1.0.0 "${CWD}/build"
+  exit
+fi
+
 
 LIGHTGBM_VERSION=$([[ -z "$1" ]] && echo "master" || echo "$1")
 PACKAGE_VERSION="$2"
@@ -29,14 +49,6 @@ if [[ -z "$PACKAGE_VERSION" ]]; then
         PACKAGE_VERSION="0.0.0"
     fi
 fi
-
-function echo_stage () {
-    echo -e "\n\n\e[1m\e[32m>>>\e[0m \e[1m$1\e[0m\n"
-}
-
-function echo_bold() {
-    echo -e "\e[1m$1\e[0m"
-}
 
 
 echo_stage "Checking need to build a new version..."

--- a/make_patch.sh
+++ b/make_patch.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2022 Feedzai
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+# @author Alberto Ferreira (alberto.ferreira@feedzai.com)
+
+set -e
+
+function echo_stage () { echo -e "\n\n\e[1m\e[32m>>>\e[0m \e[1m$1\e[0m\n"; }
+function echo_bold() { echo -e "\e[1m$1\e[0m"; }
+
+BUILD_LGBM_PATCH_FROM="$1"
+
+if [[ -z "$BUILD_LGBM_PATCH_FROM" ]]; then
+    echo "ERROR: Specify lightgbm/build/ folder where to build a patch from."
+    exit 1
+fi
+if [[ ! -f build/lib_lightgbm.so ]]; then
+    echo "ERROR: Run make.sh before make_patch.sh."
+    exit 1
+fi
+
+echo_stage "Building LGBM patch from source!"
+echo_bold "Compiling with existing CMake settings at build_dir=${BUILD_LGBM_PATCH_FROM}"
+CWD="$(pwd)"
+cd "$BUILD_LGBM_PATCH_FROM"
+make -j4
+find . -name "*.so" -exec cp {} "${CWD}/build" \;
+cp lightgbmlib.jar "${CWD}/build"
+cp $(ldd "${CWD}/build/lib_lightgbm.so" | awk '/libgomp/{print $3}') "${CWD}/build/libgomp.so.1.0.0"
+
+echo_bold "Patched LightGBM build."


### PR DESCRIPTION
Simplifies building local development patches for LightGBM. This is mandatory to have symbol compatibility when running a debugger on the host machine for instance. 

A new script `make_patch.sh` was added to compile LGBM from source in the host machine to patch the base build. `make_patch.sh`can only be run after `make.sh`.

`make_patch.sh` can also be useful when iterating on the C++ codebase, as these kind of builds are faster than the "universal/cross-platform" builds generated with `make.sh`.