### PR TITLE
Fix git-lfs install (add --install-unauthorized)

### DIFF
--- a/docker/lightgbm-ci-build-env/Dockerfile
+++ b/docker/lightgbm-ci-build-env/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update \
         libunwind8 \
         netcat \
  && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \
- && apt-get install -y --no-install-recommends git-lfs \
+ && apt-get install -y --no-install-recommends --allow-unauthenticated git-lfs \
  && rm -rf /var/lib/apt/lists/* \
  && rm -rf /etc/apt/sources.list.d/* \
  echo "UPDATED."


### PR DESCRIPTION
Recently it's no longer possible to install git-lfs without the `--install-unauthorized` flag.